### PR TITLE
License config

### DIFF
--- a/php_excel.h
+++ b/php_excel.h
@@ -22,6 +22,12 @@
 extern zend_module_entry excel_module_entry;
 #define phpext_excel_ptr &excel_module_entry
 
+ZEND_BEGIN_MODULE_GLOBALS(excel)
+	char *ini_license_name;
+	char *ini_license_key;
+ZEND_END_MODULE_GLOBALS(excel)
+
+
 #ifdef PHP_WIN32
 #define PHP_EXCEL_API __declspec(dllexport)
 #else


### PR DESCRIPTION
Here is a change to add two ini settings to configure the license configuration there instead of having to manage it in the application via the class constructor. 

This change works by checking of the class constructor is passed nothing or NULL as license_name and will check for the INI settings and use those instead.  (so to use excel 2007 you'd have to do new ExcelBook(null,null,true) )
