### PR TITLE
fixed failed tests for ExcelSheet::read()

### DIFF
--- a/excel.c
+++ b/excel.c
@@ -4642,7 +4642,7 @@ PHP_EXCEL_ARGINFO
 ZEND_BEGIN_ARG_INFO_EX(arginfo_Sheet_read, 0, 0, 2)
 	ZEND_ARG_INFO(0, row)
 	ZEND_ARG_INFO(0, column)
-	ZEND_ARG_OBJ_INFO(0, format, ExcelFormat, 1)
+	ZEND_ARG_INFO(1, format)
 	ZEND_ARG_INFO(0, read_formula)
 ZEND_END_ARG_INFO()
 


### PR DESCRIPTION
pull request #74 changed ExcelSheet::read() cell format pass-by-ref to pass-by-val but the tests failed since this breaks with the intended use case - should be reverted back to pass-by-ref
