### PR TITLE
Fix order of parameters for \ExcelAutoFilter::setRef()

### DIFF
--- a/docs/ExcelAutoFilter.php
+++ b/docs/ExcelAutoFilter.php
@@ -27,7 +27,7 @@ class ExcelAutoFilter
 	/**
 	* Gets the cell range of AutoFilter with header.
 	*
-	* @return array with keys "row_first"(int), "col_first"(int), "row_last"(int), "col_last"(int)
+	* @return array with keys "row_first"(int), "row_last"(int), "col_first"(int), "col_last"(int)
 	*/
 	public function getRef()
 	{
@@ -37,12 +37,12 @@ class ExcelAutoFilter
 	* Sets the cell range of AutoFilter with header.
 	*
 	* @param int $row_first 0-based (optional, default = 0)
-	* @param int $col_first 0-based (optional, default = 0)
 	* @param int $row_last 0-based (optional, default = 0)
+	* @param int $col_first 0-based (optional, default = 0)
 	* @param int $col_last 0-based (optional, default = 0)
 	* @return void
 	*/
-	public function setRef($row_first=0, $col_first=0, $row_last=0, $col_last=0)
+	public function setRef($row_first=0, $row_last=0, $col_first=0, $col_last=0)
 	{
 	} // setRef
 

--- a/excel.c
+++ b/excel.c
@@ -4859,15 +4859,15 @@ EXCEL_METHOD(AutoFilter, setRef)
 {
 	zval *object = getThis();
 	AutoFilterHandle autofilter;
-	zend_long rowFirst=0, colFirst=0, rowLast=0, colLast=0;
+	zend_long rowFirst=0, rowLast=0, colFirst=0, colLast=0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "llll", &rowFirst, &colFirst, &rowLast, &colLast) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "llll", &rowFirst, &rowLast, &colFirst, &colLast) == FAILURE) {
 		RETURN_FALSE;
 	}
 
 	AUTOFILTER_FROM_OBJECT(autofilter, object);
 
-	xlAutoFilterSetRef(autofilter, rowFirst, colFirst, rowLast, colLast);
+	xlAutoFilterSetRef(autofilter, rowFirst, rowLast, colFirst, colLast);
 }
 /* }}} */
 
@@ -4942,18 +4942,18 @@ EXCEL_METHOD(AutoFilter, getSortRange)
 {
 	zval *object = getThis();
 	AutoFilterHandle autofilter;
-	int rowFirst=0, colFirst=0, rowLast=0, colLast=0;
+	int rowFirst=0, rowLast=0, colFirst=0, colLast=0;
 
 	AUTOFILTER_FROM_OBJECT(autofilter, object);
 
-	if (!xlAutoFilterGetSortRange(autofilter, &rowFirst, &colFirst, &rowLast, &colLast)) {
+	if (!xlAutoFilterGetSortRange(autofilter, &rowFirst, &rowLast, &colFirst, &colLast)) {
 		RETURN_FALSE;
 	}
 
 	array_init(return_value);
 	add_assoc_long(return_value, "row_first", rowFirst);
-	add_assoc_long(return_value, "col_first", colFirst);
 	add_assoc_long(return_value, "row_last", rowLast);
+	add_assoc_long(return_value, "col_first", colFirst);
 	add_assoc_long(return_value, "col_last", rowLast);
 }
 /* }}} */


### PR DESCRIPTION
This patch reorders the PHP method parameters to be in line with
those from LibXL (see http://www.libxl.com/autoFilter.html).

Resolves: #216