### PR TITLE
xlSheetCellType override

### DIFF
--- a/docs/ExcelSheet.php
+++ b/docs/ExcelSheet.php
@@ -984,9 +984,10 @@ class ExcelSheet
 	* @param int $column 0-based column number
 	* @param &$format (optional, default=null)
 	* @param bool $read_formula (optional, default=true)
+	* @param int $celltype_override (option, default=-1)
 	* @return mixed
 	*/
-	public function read($row, $column, &$format = null, $read_formula = true)
+	public function read($row, $column, &$format = null, $read_formula = true, $celltype_override = -1)
 	{
 	} // read
 


### PR DESCRIPTION
Adds parameter to the ExcelSheet::read function enabling override of the cell type value returned by xlSheetCellType.
Doing so allows control over whether php_excel_read_cell uses xlSheetReadStr or xlSheetReadNum.

An example where this is useful would be reading long fully numeric serial numbers or IMEIs, where xlSheetCellType might indicate CELLTYPE_NUMBER, and xlSheetReadNum might return the value in exponential notation.