### PR TITLE
MINFO: emit version info as table rows, not headers

### DIFF
--- a/excel.c
+++ b/excel.c
@@ -9451,9 +9451,9 @@ PHP_MINFO_FUNCTION(excel)
 
 	php_info_print_table_start();
 	php_info_print_table_header(2, "excel support", "enabled");
-	php_info_print_table_header(2, "Excel Version", PHP_EXCEL_VERSION);
+	php_info_print_table_row(2, "Excel Version", PHP_EXCEL_VERSION);
 	snprintf(temp_api, sizeof(temp_api), "%x", LIBXL_VERSION);
-	php_info_print_table_header(2, "LibXL Version", temp_api);
+	php_info_print_table_row(2, "LibXL Version", temp_api);
 	php_info_print_table_end();
 }
 /* }}} */


### PR DESCRIPTION
## Issue
In `PHP_MINFO_FUNCTION(excel)` the "Excel Version" and "LibXL Version" lines were emitted with `php_info_print_table_header()`, which renders them as column headings rather than data rows. This is a `phpinfo()` formatting bug — version values should be data rows.

## Change
Switch the two version lines to `php_info_print_table_row()`. The leading `excel support / enabled` line is intentionally kept as a header (it serves as the section title).

```c
 php_info_print_table_start();
 php_info_print_table_header(2, "excel support", "enabled");
-php_info_print_table_header(2, "Excel Version", PHP_EXCEL_VERSION);
+php_info_print_table_row(2, "Excel Version", PHP_EXCEL_VERSION);
 snprintf(temp_api, sizeof(temp_api), "%x", LIBXL_VERSION);
-php_info_print_table_header(2, "LibXL Version", temp_api);
+php_info_print_table_row(2, "LibXL Version", temp_api);
 php_info_print_table_end();
```

Cosmetic / standards fix only; no functional behavior change. Not compiled locally (extension requires libxl + PHP dev headers) — relying on CI.

https://claude.ai/code/session_014UV6wzeYjbLaN4UUSu7CHz

---
_Generated by [Claude Code](https://claude.ai/code/session_014UV6wzeYjbLaN4UUSu7CHz)_