### PR TITLE
ExcelBook::__construct: drop dead RETURN_FALSE on missing license

### DIFF
--- a/excel.c
+++ b/excel.c
@@ -1860,16 +1860,17 @@ EXCEL_METHOD(Book, __construct)
 		key_len = strlen(key);
 	}
 
-	if (!name || name_len < 1 || !key || key_len < 1) {
-		RETURN_FALSE;
+	/* Apply a license key only when both a name and key are available
+	 * (passed explicitly, or sourced from the INI settings above). A
+	 * missing license is not a construction error: the workbook has
+	 * already been created and is usable, and PHP ignores constructor
+	 * return values anyway -- the previous RETURN_FALSE here was dead,
+	 * misleading code. Explicitly-passed NUL-bearing arguments are
+	 * already rejected at the top of the constructor; INI-sourced values
+	 * are NUL-free by construction (their length came from strlen()). */
+	if (name && name_len >= 1 && key && key_len >= 1) {
+		xlBookSetKey(book, name, key);
 	}
-
-	if (name_len != strlen(name) || key_len != strlen(key)) {
-		php_error_docref(NULL, E_WARNING, "License name/key must not contain NUL bytes");
-		RETURN_FALSE;
-	}
-
-	xlBookSetKey(book, name, key);
 
 #endif
 }


### PR DESCRIPTION
## Issue
The constructor creates the libxl book and assigns it to the object *before* reaching the `HAVE_LIBXL_SETKEY` license block, then does `RETURN_FALSE` when no license name/key is supplied. PHP ignores constructor return values, so this produced nothing observable while implying failure for a perfectly valid no-license workbook — dead, misleading code.

## Change
Replace the early `RETURN_FALSE` with a positive guard that simply skips `xlBookSetKey()` when a license isn't present:

```c
if (name && name_len >= 1 && key && key_len >= 1) {
    xlBookSetKey(book, name, key);
}
```

The redundant second NUL-byte check is also dropped:
- explicitly-passed arguments are already rejected for embedded NUL bytes at the **top** of the constructor (which throws), so they can't reach this point with a NUL;
- INI-sourced values are NUL-free by construction, since their length is taken from `strlen()`.

No observable behavior change for callers. Not compiled locally (requires libxl + PHP dev headers) — relying on CI.

https://claude.ai/code/session_014UV6wzeYjbLaN4UUSu7CHz

---
_Generated by [Claude Code](https://claude.ai/code/session_014UV6wzeYjbLaN4UUSu7CHz)_