### PR TITLE
docs: explain lastCol/lastRow boundary handling in readRow/readCol

### DIFF
--- a/excel.c
+++ b/excel.c
@@ -3234,6 +3234,11 @@ EXCEL_METHOD(Sheet, readRow)
 		RETURN_FALSE;
 	}
 
+	/* xlSheetLastCol() returns the last used column index plus one
+	 * (exclusive), so the unspecified-end default (-1) maps to the last
+	 * used column. The bounds checks deliberately allow col_start/col_end
+	 * up to lastCol() inclusive (one past the last used column); such reads
+	 * just return empty cells, so the leniency is harmless. */
 	if (col_end == -1) {
 		col_end = lc - 1;
 	}
@@ -3302,6 +3307,11 @@ EXCEL_METHOD(Sheet, readCol)
 		RETURN_FALSE;
 	}
 
+	/* xlSheetLastRow() returns the last used row index plus one (exclusive),
+	 * so the unspecified-end default (-1) maps to the last used row. The
+	 * bounds checks deliberately allow row_start/row_end up to lastRow()
+	 * inclusive (one past the last used row); such reads just return empty
+	 * cells, so the leniency is harmless. */
 	if (row_end == -1) {
 		row_end = lc - 1;
 	}


### PR DESCRIPTION
## Summary

Comment-only clarification (no logic change) for `ExcelSheet::readRow()` and `ExcelSheet::readCol()`.

`xlSheetLastCol()` / `xlSheetLastRow()` return the last used index **plus one** (exclusive). That is why:
- the unspecified-end default (`-1`) maps to `lastCol()-1` / `lastRow()-1` (the last *used* column/row), and
- the range checks permit an explicit end up to `lastCol()` / `lastRow()` **inclusive** (one past the last used cell).

Reading one past the last used cell simply yields empty cells, so the apparent off-by-one between the default and the bound is intentional and harmless. The added comments document this so the next reader doesn't "fix" it into a regression that drops a row/column.

## Change

10 lines added, all comments. Brace balance unchanged; verified diff contains zero non-comment additions.

## Testing

Comment-only — no behavioral impact. CI builds it as a sanity check.

https://claude.ai/code/session_014UV6wzeYjbLaN4UUSu7CHz

---
_Generated by [Claude Code](https://claude.ai/code/session_014UV6wzeYjbLaN4UUSu7CHz)_