### PR TITLE
Support PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.3', '8.4', '8.5']
+        php: ['8.1', '8.2', '8.3', '8.4', '8.5']
         libxl: ['5.2.0.1']
         include:
           - php: '8.4'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,7 +22,7 @@ jobs:
         uses: php/php-windows-builder/extension-matrix@v1
         with:
           extension-url: ${{ github.event.repository.html_url }}
-          php-version-list: '8.3, 8.4, 8.5'
+          php-version-list: '8.1, 8.2, 8.3, 8.4, 8.5'
 
   windows-build:
     name: Build ${{ matrix.php-version }} ${{ matrix.arch }} ${{ matrix.ts }}

--- a/.release-config
+++ b/.release-config
@@ -5,6 +5,8 @@ version_macro: PHP_EXCEL_VERSION
 version_file: excel.c
 repo: iliaal/php_excel
 build_matrix:
+  - PHP-8.1
+  - PHP-8.2
   - PHP-8.3
   - PHP-8.4
   - PHP-8.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- PHP 8.1 support (lowered the minimum from 8.3).
+
 ## [2.1.0] - 2026-06-01
 
 ### Added

--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@
 
 ![php_excel: 7-10× faster Excel I/O for PHP](images/php_excel-hero.jpg)
 
-Native C extension for reading and writing Excel files in PHP, powered by [LibXL](http://www.libxl.com/). 7-10× faster than PhpSpreadsheet with substantially lower memory pressure. Full XLS and XLSX support: rich text, conditional formatting, formulas, autofilters, form controls, embedded charts, and structured tables. PHP 8.3+ minimum. 2.0 ground-up modernization shipped April 2026.
+Native C extension for reading and writing Excel files in PHP, powered by [LibXL](http://www.libxl.com/). 7-10× faster than PhpSpreadsheet with substantially lower memory pressure. Full XLS and XLSX support: rich text, conditional formatting, formulas, autofilters, form controls, embedded charts, and structured tables. PHP 8.1+ minimum. 2.0 ground-up modernization shipped April 2026.
 
 ## 🚀 Install
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=8.3"
+        "php": ">=8.1"
     },
     "php-ext": {
         "extension-name": "excel",

--- a/config.m4
+++ b/config.m4
@@ -14,10 +14,10 @@ PHP_ARG_ENABLE(excel-dev, whether to enable developer build flags,
 
 if test "$PHP_EXCEL" != "no"; then
 
-  dnl Check minimum PHP version (8.3.0 = 80300)
+  dnl Check minimum PHP version (8.1.0 = 80100)
   PHP_VERSION_ID=$($PHP_CONFIG --vernum)
-  if test "$PHP_VERSION_ID" -lt "80300"; then
-    AC_MSG_ERROR([php_excel requires PHP 8.3.0 or later (found $PHP_VERSION_ID)])
+  if test "$PHP_VERSION_ID" -lt "80100"; then
+    AC_MSG_ERROR([php_excel requires PHP 8.1.0 or later (found $PHP_VERSION_ID)])
   fi
 
   SEARCH_PATH="/usr/local /usr"

--- a/excel.c
+++ b/excel.c
@@ -68,6 +68,16 @@ PHP_INI_BEGIN()
 PHP_INI_END()
 
 /* {{{ OO init/structure stuff */
+/* default_object_handlers is a class-entry field added in PHP 8.3; on
+ * 8.1/8.2 each create_object handler sets intern->std.handlers directly,
+ * which is the correct per-object mechanism there. */
+#if PHP_VERSION_ID >= 80300
+#define EXCEL_SET_DEFAULT_OBJECT_HANDLERS(c_name) \
+	excel_ce_ ## c_name->default_object_handlers = &excel_object_handlers_ ## c_name
+#else
+#define EXCEL_SET_DEFAULT_OBJECT_HANDLERS(c_name) ((void)0)
+#endif
+
 /* Class registration uses the gen_stub-generated register_class_*()
  * functions from excel_arginfo.h; this macro layers on create_object,
  * NOT_SERIALIZABLE, and per-class object_handlers. */
@@ -77,7 +87,7 @@ PHP_INI_END()
 		excel_ce_ ## c_name->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE; \
 		excel_ce_ ## c_name->create_object = excel_object_new_ ## c_name; \
 		memcpy(&excel_object_handlers_ ## c_name, zend_get_std_object_handlers(), sizeof(zend_object_handlers)); \
-		excel_ce_ ## c_name->default_object_handlers = &excel_object_handlers_ ## c_name; \
+		EXCEL_SET_DEFAULT_OBJECT_HANDLERS(c_name); \
 		excel_object_handlers_ ## c_name .offset = offsetof(excel_ ## c_name ## _object, std); \
 		excel_object_handlers_ ## c_name .free_obj = excel_ ## c_name ## _object_free_storage; \
 		excel_object_handlers_ ## c_name .clone_obj = clone; \


### PR DESCRIPTION
Lowers the minimum from 8.3 to 8.1.

## Blocker + fix

The only 8.3+ dependency was the class-entry `default_object_handlers` field assigned in the `REGISTER_EXCEL_CLASS` macro. Guarded with `#if PHP_VERSION_ID >= 80300`. No `#else` needed: each `create_object` handler already sets `intern->std.handlers` directly (verified across all 12 classes), which is the correct per-object mechanism on 8.1/8.2.

## Floor + CI

- `config.m4`: vernum gate `80300` -> `80100`, error message updated to "8.1.0 or later".
- `composer.json`: `>=8.3` -> `>=8.1`. `README.markdown`: "PHP 8.1+ minimum".
- Added 8.1 and 8.2 to the linux test matrix (tests.yml), the Windows `php-version-list` (windows.yml), and `build_matrix` in .release-config.

## Verification

Built clean (0 warnings, 0 errors) and ran the full suite against local ASAN PHP 8.1.34 and 8.2.31:

| PHP | passed | failed | skipped |
|-----|--------|--------|---------|
| 8.1 | 155 | 0 | 2 |
| 8.2 | 155 | 0 | 2 |

Both skips are license-gated (`isLicensed()` / licensed row-0 access) with no libxl key set — environment, not version. Runtime smoke test confirms object handlers wire correctly on 8.1.